### PR TITLE
Make select device required

### DIFF
--- a/Qudify/Qudify/Scripts/BoomBox.cs
+++ b/Qudify/Qudify/Scripts/BoomBox.cs
@@ -24,6 +24,18 @@ namespace XRL.World.Parts
 
             if (SpotifyLoader.Profile.IsPremium)
             {
+                if (!SelectedSpotifyDevice.HasSelectedDevice())
+                {
+                    E.AddAction(
+                        Name: "Select Device",
+                        Key: 'D',
+                        Display: "Select {{W|D}}evice",
+                        Command: SpotifyCommands.SELECT_DEVICE
+                    );
+
+                    return true;
+                }
+
                 var playbackState = SpotifyClient.GetPlaybackState();
                 if (playbackState != null && playbackState.is_playing)
                 {

--- a/Qudify/Qudify/Scripts/QudifyActions.cs
+++ b/Qudify/Qudify/Scripts/QudifyActions.cs
@@ -21,7 +21,7 @@ namespace Qudify.Qudify.Scripts
 
         public static void Search()
         {
-            if (!SpotifyLoader.CheckPremium())
+            if (!SpotifyLoader.ValidateRequest())
             {
                 return;
             }
@@ -82,7 +82,7 @@ namespace Qudify.Qudify.Scripts
 
         public static void SetVolume()
         {
-            if (!SpotifyLoader.CheckPremium())
+            if (!SpotifyLoader.ValidateRequest())
             {
                 return;
             }
@@ -103,10 +103,20 @@ namespace Qudify.Qudify.Scripts
 
         public static void SelectDevice()
         {
-            var availableDevices = SpotifyClient.GetAvailableDevices();
+            if (!SpotifyLoader.ValidateRequest(validateSelectDevices: false))
+            {
+                return;
+            }
+
+            var availableDevices = SpotifyClient.GetAvailableDevices(checkPremium: false);
             if (availableDevices != null && availableDevices.devices.Length > 0)
             {
-                var names = availableDevices.devices.Select(d => d.name).ToList();
+                var names = availableDevices
+                    .devices
+                    .Select(d => 
+                    {
+                        return d.name == Environment.MachineName ? $"{d.name} - current machine" : d.name;
+                    }).ToList();
                 var index = Popup.ShowOptionList(
                     Title: "Select Device",
                     Options: names,

--- a/Qudify/Qudify/Scripts/Spotify/SelectedSpotifyDevice.cs
+++ b/Qudify/Qudify/Scripts/Spotify/SelectedSpotifyDevice.cs
@@ -5,5 +5,10 @@ namespace Qudify.Scripts.Spotify
     internal class SelectedSpotifyDevice
     {
         public static SpotifyDevice SelectedDevice { get; set; }
+
+        public static bool HasSelectedDevice()
+        {
+            return SelectedDevice != null;
+        }
     }
 }

--- a/Qudify/Qudify/Scripts/Spotify/SpotifyClient.cs
+++ b/Qudify/Qudify/Scripts/Spotify/SpotifyClient.cs
@@ -160,7 +160,7 @@ namespace Qudify.Scripts.Spotify
 
         public static AvailableDevicesResponse GetAvailableDevices(bool checkPremium)
         {
-            if (SpotifyLoader.GetToken() == null || (checkPremium && !SpotifyLoader.CheckPremium()))
+            if (SpotifyLoader.GetToken() == null || (checkPremium && !SpotifyLoader.ValidateRequest()))
             {
                 return new AvailableDevicesResponse();
             }
@@ -205,7 +205,7 @@ namespace Qudify.Scripts.Spotify
 
         public static void TransferPlayback(string deviceId)
         {
-            if (SpotifyLoader.GetToken() == null || !SpotifyLoader.CheckPremium())
+            if (SpotifyLoader.GetToken() == null || !SpotifyLoader.ValidateRequest(validateSelectDevices: false))
             {
                 return;
             }
@@ -371,7 +371,7 @@ namespace Qudify.Scripts.Spotify
 
         public static void SkipToNext()
         {
-            if (SpotifyLoader.GetToken() == null || !SpotifyLoader.CheckPremium())
+            if (SpotifyLoader.GetToken() == null || !SpotifyLoader.ValidateRequest())
             {
                 return;
             }
@@ -397,7 +397,7 @@ namespace Qudify.Scripts.Spotify
 
         public static void SkipToPrevious()
         {
-            if (SpotifyLoader.GetToken() == null || !SpotifyLoader.CheckPremium())
+            if (SpotifyLoader.GetToken() == null || !SpotifyLoader.ValidateRequest())
             {
                 return;
             }

--- a/Qudify/Qudify/Scripts/Spotify/SpotifyLoader.cs
+++ b/Qudify/Qudify/Scripts/Spotify/SpotifyLoader.cs
@@ -65,18 +65,33 @@ namespace Qudify.Scripts.Spotify
 
         internal static bool IsLoggedIn() { return token != null; }
 
-        internal static bool CheckPremium()
+        internal static bool ValidateRequest()
         {
-            if (!Profile.IsPremium)
+            return ValidateRequest(validateSelectDevices: true);
+        }
+
+        internal static bool ValidateRequest(bool validateSelectDevices)
+        {
+            if (!CheckPremium())
             {
                 Popup.Show("You need to have a Premium account to do this action.");
                 return false;
             }
 
-            var availableDevices = SpotifyClient.GetAvailableDevices(false);
-            if (!availableDevices.HasDevice(Environment.MachineName))
+            if (validateSelectDevices && !SelectedSpotifyDevice.HasSelectedDevice()) {
+                Popup.Show("You need to select a device to do this action.");
+                return false;
+            }
+
+
+            return true;
+        }
+
+        private static bool CheckPremium()
+        {
+            if (!Profile.IsPremium)
             {
-                Popup.Show($"No Spotify player on machine {Environment.MachineName} exists. Start it up on this machine and try again.");
+                Popup.Show("You need to have a Premium account to do this action.");
                 return false;
             }
 

--- a/Qudify/Qudify/workshop.json
+++ b/Qudify/Qudify/workshop.json
@@ -1,7 +1,7 @@
 {
   "WorkshopId": 3349904580,
   "Title": "Qudify",
-  "Description": "Creates an item to control your Spotify player within the game.",
+  "Description": "Creates an item to control your Spotify player within the game.\n\nDocumentation:\nhttps://github.com/caklimas/caves-of-qud-mods/blob/main/docs/Qudify.md",
   "Tags": "",
   "Visibility": "0",
   "ImagePath": "preview.png"


### PR DESCRIPTION
Updated check to make sure the user is connected and also has selected a device before doing other actions